### PR TITLE
Fixed "Chop down if long" formatter behaviour when parameters list is too long.

### DIFF
--- a/src/org/jetbrains/plugins/scala/lang/formatting/getDummyBlocks.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/getDummyBlocks.scala
@@ -120,9 +120,7 @@ object getDummyBlocks {
       }
       case _ =>
     }
-    val alignment: Alignment = if (mustAlignment(node, block.getSettings))
-      Alignment.createAlignment
-    else null
+    val alignment = if (mustAlignment(node, block.getSettings)) Alignment.createAlignment else null
     var alternateAlignment: Alignment = null
     for (child <- children if isCorrectBlock(child)) {
       val indent = ScalaIndentProcessor.getChildIndent(block, child)
@@ -644,7 +642,6 @@ object getDummyBlocks {
     node.getPsi match {
       case _: ScXmlStartTag => true  //todo:
       case _: ScXmlEmptyTag => true   //todo:
-      case _: ScParameters if mySettings.ALIGN_MULTILINE_PARAMETERS => true
       case _: ScParameterClause if mySettings.ALIGN_MULTILINE_PARAMETERS => true
       case _: ScTemplateParents if mySettings.ALIGN_MULTILINE_EXTENDS_LIST => true
       case _: ScArgumentExprList if mySettings.ALIGN_MULTILINE_PARAMETERS_IN_CALLS  ||

--- a/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
+++ b/src/org/jetbrains/plugins/scala/lang/formatting/processors/ScalaIndentProcessor.scala
@@ -168,17 +168,17 @@ object ScalaIndentProcessor extends ScalaTokenTypes {
       case _: ScExtendsBlock if settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED ||
         settings.CLASS_BRACE_STYLE == CommonCodeStyleSettings.NEXT_LINE_SHIFTED2 => Indent.getNormalIndent
       case _: ScExtendsBlock => Indent.getNoneIndent //Template body
-      case cl: ScParameterClause if  scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
-        if (child.getElementType == ScalaTokenTypes.tRPARENTHESIS) Indent.getNoneIndent
-        else {
-          val parent = node.getTreeParent
-          if (parent != null && parent.getPsi.isInstanceOf[ScParameters] && parent.getTreeParent != null) {
-            if (parent.getTreeParent.getPsi.isInstanceOf[ScFunctionExpr]) {
-              return Indent.getNoneIndent
-            }
+      case _: ScParameterClause if child.getElementType == ScalaTokenTypes.tRPARENTHESIS ||
+                                   child.getElementType == ScalaTokenTypes.tLPARENTHESIS =>
+        Indent.getNoneIndent
+      case _: ScParameterClause if scalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS =>
+        val parent = node.getTreeParent
+        if (parent != null && parent.getPsi.isInstanceOf[ScParameters] && parent.getTreeParent != null) {
+          if (parent.getTreeParent.getPsi.isInstanceOf[ScFunctionExpr]) {
+            return Indent.getNoneIndent
           }
-          Indent.getNormalIndent
         }
+        Indent.getNormalIndent
       case _: ScParenthesisedExpr | _: ScParenthesisedPattern | _: ScParenthesisedExpr =>
         Indent.getContinuationWithoutFirstIndent(settings.ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION)
 //      case paramClause : ScParameterClause if child.getTreePrev != null && child.getTreePrev.getPsi.isInstanceOf[PsiWhiteSpace] && child.getTreePrev.getText.contains("\n") =>

--- a/test/org/jetbrains/plugins/scala/lang/formatter/tests/ScalaWrappingAndBracesTest.scala
+++ b/test/org/jetbrains/plugins/scala/lang/formatter/tests/ScalaWrappingAndBracesTest.scala
@@ -314,4 +314,36 @@ class B extends A
     doTextTest(before, after)
   }
 
+  def testChopDown() {
+    getSettings.setRightMargin(null, 50)
+    getIndentOptions.CONTINUATION_INDENT_SIZE = 2
+    getCommonSettings.METHOD_PARAMETERS_WRAP = CommonCodeStyleSettings.WRAP_ON_EVERY_ITEM
+    getCommonSettings.METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE = true
+    getCommonSettings.METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE = true
+    getScalaSettings.NOT_CONTINUATION_INDENT_FOR_PARAMS = true
+    val before =
+""" 
+class Foo {
+  def methodWithTooManyParamsForALine(param1: Bar, param2: Bar, param3: Bar, param4: Bar, param5: Bar, param6: Bar) = {
+    // some code
+  }
+}
+""".replace("\r", "")
+    val after =
+"""
+class Foo {
+  def methodWithTooManyParamsForALine(
+    param1: Bar,
+    param2: Bar,
+    param3: Bar,
+    param4: Bar,
+    param5: Bar,
+    param6: Bar
+  ) = {
+    // some code
+  }
+}
+""".replace("\r", "")
+    doTextTest(before, after)
+  }
 }

--- a/testdata/formatter/data/indent/function/functionParam1.test
+++ b/testdata/formatter/data/indent/function/functionParam1.test
@@ -6,6 +6,6 @@ class a {
 -----
 class a {
   abstract def foo()()
-                  () =
+    () =
     true
 }

--- a/testdata/formatter/data/indent/function/functionParam2.test
+++ b/testdata/formatter/data/indent/function/functionParam2.test
@@ -1,0 +1,13 @@
+class a {
+  def top[V] (
+    bar: Seq[V]
+  ) (implicit ord: Ordering[V]) =
+  bar.sorted.headOption
+}
+-----
+class a {
+  def top[V](
+    bar: Seq[V]
+  )(implicit ord: Ordering[V]) =
+    bar.sorted.headOption
+}


### PR DESCRIPTION
Fixed "Chop down if long" formatter behaviour when parameters list is too long.

Before because of an aligment for children of ScParameters a ScalaBlock for ScParameterClause child was indented according to '('

for example:

def foo(param1: Bar, param2: Bar) = {}

was reformatted to:

def foo(
              param1: Bar,
              param2: Bar
) = {}

now it will become:

def foo(
  param1: Bar,
  param2: Bar
) = {}

See a test case that I've added. Also all tests in org.jetbrains.plugins.scala.lang.formatter package are passing.